### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 python-clewareampel
 ===================
 
-[![version](https://pypip.in/v/clewareampel/badge.png?style=flat)](https://pypi.python.org/pypi/clewareampel)
-[![Supported Python versions](https://pypip.in/py_versions/clewareampel/badge.svg?style=flat)](https://pypi.python.org/pypi/clewareampel/)
-[![format](https://pypip.in/format/clewareampel/badge.png?style=flat)](https://pypi.python.org/pypi/clewareampel)
-[![downloads](https://pypip.in/d/clewareampel/badge.png?style=flat)](https://pypi.python.org/pypi/clewareampel)
-[![license](https://pypip.in/license/clewareampel/badge.png?style=flat)](https://pypi.python.org/pypi/clewareampel)
+[![version](https://img.shields.io/pypi/v/clewareampel.svg?style=flat)](https://pypi.python.org/pypi/clewareampel)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/clewareampel.svg?style=flat)](https://pypi.python.org/pypi/clewareampel/)
+[![format](https://img.shields.io/pypi/format/clewareampel.svg?style=flat)](https://pypi.python.org/pypi/clewareampel)
+[![downloads](https://img.shields.io/pypi/dm/clewareampel.svg?style=flat)](https://pypi.python.org/pypi/clewareampel)
+[![license](https://img.shields.io/pypi/l/clewareampel.svg?style=flat)](https://pypi.python.org/pypi/clewareampel)
 
 Control the Cleware USB Ampel (traffic lights) with Python.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20clewareampel))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `clewareampel`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.